### PR TITLE
Fix sign-in button and add language selector

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { BookPage } from './pages/BookPage';
 import { CommunityPage } from './pages/CommunityPage';
 import { AuthProvider } from './contexts/AuthContext';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { LanguageProvider } from './contexts/LanguageContext';
 
 export type PageType = 'home' | 'writing' | 'discovery' | 'profile' | 'book' | 'community';
 
@@ -35,16 +36,18 @@ function App() {
   };
 
   return (
-    <ThemeProvider>
-      <AuthProvider>
-        <div className="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
-          <Navigation currentPage={currentPage} onNavigate={setCurrentPage} />
-          <main className="pt-16">
-            {renderPage()}
-          </main>
-        </div>
-      </AuthProvider>
-    </ThemeProvider>
+    <LanguageProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <div className="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
+            <Navigation currentPage={currentPage} onNavigate={setCurrentPage} />
+            <main className="pt-16">
+              {renderPage()}
+            </main>
+          </div>
+        </AuthProvider>
+      </ThemeProvider>
+    </LanguageProvider>
   );
 }
 

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { X, Mail, Lock, User, Eye, EyeOff } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import { useLanguage } from '../contexts/LanguageContext';
 
 interface AuthModalProps {
   isOpen: boolean;
@@ -22,6 +23,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose }) => {
   });
 
   const { signIn, signUp } = useAuth();
+  const { t } = useLanguage();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -67,7 +69,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose }) => {
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-md mx-4">
         <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
           <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-            {isLogin ? 'Sign In' : 'Create Account'}
+            {isLogin ? t('signIn') : t('createAccount')}
           </h2>
           <button
             onClick={onClose}
@@ -192,7 +194,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose }) => {
             disabled={loading}
             className="w-full bg-blue-600 text-white py-3 rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {loading ? 'Please wait...' : (isLogin ? 'Sign In' : 'Create Account')}
+            {loading ? t('pleaseWait') : (isLogin ? t('signIn') : t('createAccount'))}
           </button>
 
           <div className="text-center">
@@ -201,7 +203,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose }) => {
               onClick={() => setIsLogin(!isLogin)}
               className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 text-sm"
             >
-              {isLogin ? "Don't have an account? Sign up" : 'Already have an account? Sign in'}
+              {isLogin ? t('noAccount') : t('haveAccount')}
             </button>
           </div>
         </form>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Book, Home, Search, User, Users, PenTool, Bell, Settings, Moon, Sun } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
+import { useLanguage } from '../contexts/LanguageContext';
 import { PageType } from '../App';
 import { AuthModal } from './AuthModal';
 
@@ -13,13 +14,14 @@ interface NavigationProps {
 export const Navigation: React.FC<NavigationProps> = ({ currentPage, onNavigate }) => {
   const { user, profile, signIn, signOut, loading } = useAuth();
   const { theme, toggleTheme } = useTheme();
+  const { language, setLanguage, t } = useLanguage();
   const [showAuthModal, setShowAuthModal] = React.useState(false);
 
   const navItems = [
-    { id: 'home', label: 'Home', icon: Home },
-    { id: 'discovery', label: 'Discover', icon: Search },
-    { id: 'writing', label: 'Write', icon: PenTool },
-    { id: 'community', label: 'Community', icon: Users },
+    { id: 'home', label: t('home'), icon: Home },
+    { id: 'discovery', label: t('discover'), icon: Search },
+    { id: 'writing', label: t('write'), icon: PenTool },
+    { id: 'community', label: t('community'), icon: Users },
   ];
 
   return (
@@ -56,11 +58,20 @@ export const Navigation: React.FC<NavigationProps> = ({ currentPage, onNavigate 
           {/* Right Side Actions */}
           <div className="flex items-center space-x-4">
             <button
-              onClick={() => setShowAuthModal(true)}
+              onClick={toggleTheme}
               className="p-2 rounded-md text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
             >
               {theme === 'dark' ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
             </button>
+
+            <select
+              value={language}
+              onChange={(e) => setLanguage(e.target.value as 'en' | 'fr')}
+              className="bg-transparent border border-gray-300 dark:border-gray-600 text-sm rounded-md p-1"
+            >
+              <option value="en">EN</option>
+              <option value="fr">FR</option>
+            </select>
 
             {user && profile ? (
               <div className="flex items-center space-x-3">
@@ -82,15 +93,15 @@ export const Navigation: React.FC<NavigationProps> = ({ currentPage, onNavigate 
                   onClick={signOut}
                   className="text-sm text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
                 >
-                  Logout
+                  {t('logout')}
                 </button>
               </div>
             ) : !loading && (
               <button
-                onClick={() => {/* TODO: Open login modal */}}
+                onClick={() => setShowAuthModal(true)}
                 className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors"
               >
-                Sign In
+                {t('signIn')}
               </button>
             )}
           </div>

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,0 +1,70 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+type Language = 'en' | 'fr';
+
+const translations = {
+  en: {
+    home: 'Home',
+    discover: 'Discover',
+    write: 'Write',
+    community: 'Community',
+    signIn: 'Sign In',
+    logout: 'Logout',
+    heroTitle: 'Where Stories Come to Life',
+    heroWriteCTA: 'Start Writing Today',
+    heroDiscoverCTA: 'Discover Amazing Stories',
+    createAccount: 'Create Account',
+    pleaseWait: 'Please wait...',
+    noAccount: "Don't have an account? Sign up",
+    haveAccount: 'Already have an account? Sign in'
+  },
+  fr: {
+    home: 'Accueil',
+    discover: 'Découvrir',
+    write: 'Écrire',
+    community: 'Communauté',
+    signIn: 'Se connecter',
+    logout: 'Déconnexion',
+    heroTitle: 'Là où les histoires prennent vie',
+    heroWriteCTA: "Commencez à écrire aujourd'hui",
+    heroDiscoverCTA: 'Découvrez des histoires incroyables',
+    createAccount: 'Créer un compte',
+    pleaseWait: 'Veuillez patienter...',
+    noAccount: "Vous n'avez pas de compte ? Inscrivez-vous",
+    haveAccount: 'Vous avez déjà un compte ? Connectez-vous'
+  }
+};
+
+type TranslationKey = keyof typeof translations['en'];
+
+interface LanguageContextType {
+  language: Language;
+  setLanguage: (lang: Language) => void;
+  t: (key: TranslationKey) => string;
+}
+
+const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
+
+export const useLanguage = () => {
+  const context = useContext(LanguageContext);
+  if (context === undefined) {
+    throw new Error('useLanguage must be used within a LanguageProvider');
+  }
+  return context;
+};
+
+interface LanguageProviderProps {
+  children: ReactNode;
+}
+
+export const LanguageProvider: React.FC<LanguageProviderProps> = ({ children }) => {
+  const [language, setLanguage] = useState<Language>('en');
+  const t = (key: TranslationKey) => translations[language][key];
+  const value = { language, setLanguage, t };
+  return (
+    <LanguageContext.Provider value={value}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { TrendingUp, Clock, Star, Users, BookOpen, Award } from 'lucide-react';
 import { PageType } from '../App';
 import { useAuth } from '../contexts/AuthContext';
+import { useLanguage } from '../contexts/LanguageContext';
 
 interface HomePageProps {
   onNavigate: (page: PageType) => void;
@@ -9,6 +10,7 @@ interface HomePageProps {
 
 export const HomePage: React.FC<HomePageProps> = ({ onNavigate }) => {
   const { user } = useAuth();
+  const { t } = useLanguage();
 
   const featuredBooks = [
     {
@@ -55,7 +57,7 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate }) => {
       {/* Hero Section */}
       <div className="text-center mb-16">
         <h1 className="text-4xl md:text-6xl font-bold text-gray-900 dark:text-white mb-6">
-          Where Stories Come to Life
+          {t('heroTitle')}
         </h1>
         <p className="text-xl text-gray-600 dark:text-gray-300 mb-8 max-w-3xl mx-auto">
           Join a vibrant community of writers who collaborate, critique, and celebrate storytelling. 
@@ -66,13 +68,13 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate }) => {
             onClick={() => onNavigate('writing')}
             className="bg-blue-600 text-white px-8 py-3 rounded-lg hover:bg-blue-700 transition-colors font-semibold"
           >
-            Start Writing Today
+            {t('heroWriteCTA')}
           </button>
           <button
             onClick={() => onNavigate('discovery')}
             className="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 px-8 py-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors font-semibold"
           >
-            Discover Amazing Stories
+            {t('heroDiscoverCTA')}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- hook up sign-in button to auth modal
- toggle theme properly and add language selector
- translate navigation, home hero, and auth modal
- add language context provider

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6875374393848321ba26b90c0d8b3104