### PR TITLE
Fix language persistence

### DIFF
--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -58,14 +58,10 @@ interface LanguageProviderProps {
 }
 
 export const LanguageProvider: React.FC<LanguageProviderProps> = ({ children }) => {
-  const [language, setLanguage] = useState<Language>('en');
-
-  useEffect(() => {
-    const savedLanguage = localStorage.getItem('language') as Language;
-    if (savedLanguage) {
-      setLanguage(savedLanguage);
-    }
-  }, []);
+  const [language, setLanguage] = useState<Language>(() => {
+    const saved = localStorage.getItem('language');
+    return saved === 'fr' || saved === 'en' ? (saved as Language) : 'en';
+  });
 
   useEffect(() => {
     localStorage.setItem('language', language);


### PR DESCRIPTION
## Summary
- ensure language choice is loaded from localStorage at startup

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/PageTurnerTwo/node_modules/@eslint/js/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_68753b3caccc83218a0f4de88ee9dafb